### PR TITLE
.NETstandard2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ git:
 
 matrix:
   include:
-    - dotnet: 2.2.104
+    - dotnet: 3.1.101
       mono: none
-      env: DOTNETCORE=2
+      env: DOTNETCORE=3
 
 before_install:
   - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules

--- a/Digipost.Api.Client.DataTypes.Core/Digipost.Api.Client.DataTypes.Core.csproj
+++ b/Digipost.Api.Client.DataTypes.Core/Digipost.Api.Client.DataTypes.Core.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <RootNamespace>Digipost.Api.Client.DataTypes.Core</RootNamespace>
         <AssemblyName>Digipost.Api.Client.DataTypes.Core</AssemblyName>
         <ProjectGuid>{2DF4659A-DFF9-4DF6-8B5D-B1FDE55DA498}</ProjectGuid>
@@ -38,7 +38,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Digipost.Api.Client.Shared" Version="5.0.0" />
+      <PackageReference Include="Digipost.Api.Client.Shared" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Digipost.Api.Client.DataTypes.Tests/Digipost.Api.Client.DataTypes.Tests.csproj
+++ b/Digipost.Api.Client.DataTypes.Tests/Digipost.Api.Client.DataTypes.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <RootNamespace>Digipost.Api.Client.DataTypes.Tests</RootNamespace>
         <AssemblyName>Digipost.Api.Client.DataTypes.Tests</AssemblyName>
         <ProjectGuid>{8814CB98-13B3-4CDF-A081-D1470F80D38B}</ProjectGuid>
@@ -37,7 +37,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="5.0.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.5" />

--- a/Digipost.Api.Client.DataTypes.Utils/Digipost.Api.Client.DataTypes.Utils.csproj
+++ b/Digipost.Api.Client.DataTypes.Utils/Digipost.Api.Client.DataTypes.Utils.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <RootNamespace>Digipost.Api.Client.DataTypes.Utils</RootNamespace>
         <AssemblyName>Digipost.Api.Client.DataTypes.Utils</AssemblyName>
         <ProjectGuid>{A6CC23AB-6E38-42D1-9DDE-854AFB428E05}</ProjectGuid>


### PR DESCRIPTION
Flytter prosjektet over til `.NETstandard2.0`.
Tar i bruk github actions for bygging parallelt med travis til vi får erstattet det.